### PR TITLE
TOC 기준 선택자를 자식 선택자에서 하위 선택자로 변경

### DIFF
--- a/views/Main/Post/Permalink/Post/Content.pug
+++ b/views/Main/Post/Permalink/Post/Content.pug
@@ -21,7 +21,7 @@ script(once='alpine-content-component').
      *
      * @property {array} headings
      */
-    supportHeadings: '.contents_style > h2, .contents_style > h3',
+    supportHeadings: '.contents_style h2, .contents_style h3',
 
     /**
      * Headings


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/44552838/216627035-d87fb7f1-5d75-4750-b57a-1a1b29d77676.png)


외부 에디터를 통해서 작성한 글을 붙여넣기 하는 경우에 가끔 html 구조에서 새로운 div가 생성된 채로 붙여 넣어지는 경우가 있습니다.

아마 티스토리 자체 에디터에서 붙여넣기를 처리하는 방식으로 인해서 생기는 버그로 보이는데요, 이런 경우에는 아무리 h2, h3로 설정을 해도 TOC에 나오지 않기 때문에, 직접 html 에디터를 통해서 수정해주어야 합니다.

이런 경우 `html에 익숙하지 않은 일반인`들이 사용하기에 매우 불편할 것으로 생각되어 다른 분들도 사용하실 수 있도록 PR을 올렸습니다.

확인해보시고 괜찮으시면 반영 부탁드립니다. 🙇🏻‍♂️

아울러, 훌륭한 스킨 만들어주셔서 감사합니다 :)